### PR TITLE
Language switch using a string

### DIFF
--- a/lib/Chemistry/Elements.pm6
+++ b/lib/Chemistry/Elements.pm6
@@ -158,12 +158,31 @@ class Chemistry::Elements {
 		%symbol_to_name{$_}:exists or warn "<$_> is not a recognized chemical symbol";
 		};
 
-	# In the following functions $lang is used to declare the language for the query/result
+	# In the following functions $lang is used to declare the language for the query/result. 
+	# The lang_str_to_int method converts the language string to the language index.
 
-	method get_name_by_Z ( ZInt(Cool) $Z, int $lang ) returns Str {
-		%names{$Z}[$lang];
+	method lang_str_to_int (str $l) returns int {
+		given $l {
+			when "pigLat" {
+					return 0;
+				}
+			when "en" {
+					return 1;
+				}
+			when "de" {
+					return 2;
+				}
+			default {
+				return 1;
+				}
+			}
 		}
-	method get_name_by_symbol ( ChemicalSymbol $symbol, int $lang ) returns Str {
+
+	method get_name_by_Z ( ZInt(Cool) $Z, Str $lang = "default" ) returns Str {
+		%names{$Z}[self.lang_str_to_int($lang)];
+		}
+
+	method get_name_by_symbol ( ChemicalSymbol $symbol, Str $lang = "default" ) returns Str {
 		self.get_name_by_Z( self.get_Z_by_symbol( $symbol ), $lang );
 		}
 
@@ -177,7 +196,7 @@ class Chemistry::Elements {
 	method get_Z_by_symbol ( ChemicalSymbol $symbol ) returns ZInt {
 		%symbol_to_name{$symbol}:exists ?? %symbol_to_name{$symbol} !! die;
 		}
-	method get_Z_by_name ( Str $name, int $lang ) returns ZInt {
+	method get_Z_by_name ( Str $name, Str $lang = "default" ) returns ZInt {
 		die "get_Z_by_name not yet implemented";
 		}
 

--- a/t/010.get_name_by_Z.t
+++ b/t/010.get_name_by_Z.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 13;
+plan 15;
 
 my $package = 'Chemistry::Elements';
 my $method  = 'get_name_by_Z';
@@ -17,35 +17,43 @@ can-ok $class, $method;
 my $callable = $class.^find_method( $method );
 
 is
-	$class."$method"(37, 1), 'Rubidium',
+	$class."$method"(37), 'Rubidium',
 	'Z=37 is Rubidium';
 
 is
-	$class."$method"(37, 2), 'Rubidium',
+	$class."$method"(37, "en"), 'Rubidium',
+	'Z=37 is Rubidium';
+
+is
+	$class."$method"(37, "de"), 'Rubidium',
 	'Z=37 ist Rubidium';
 
 is
-	$class.$callable(1, 1), 'Hydrogen',
+	$class.$callable(1), 'Hydrogen',
 	'Z=1 is Hydrogen';
 
 is
-	$class."$method"(1, 2), 'Wasserstoff',
+	$class.$callable(1, "en"), 'Hydrogen',
+	'Z=1 is Hydrogen';
+
+is
+	$class."$method"(1, "de"), 'Wasserstoff',
 	'Z=1 is Wasserstoff';
 
-lives-ok { for 1..118 -> $Z { $class."$method"($Z, 1) } },
+lives-ok { for 1..118 -> $Z { $class."$method"($Z, "en") } },
 	'Z is valid for 1 to 118';
 
-lives-ok { $class."$method"("37", 1) }, 'Z is valid Str "37"';
+lives-ok { $class."$method"("37", "en") }, 'Z is valid Str "37"';
 
 # invalid because they are not in the numeric range
-dies-ok { $class."$method"(119, 1) }, '119 is not a valid Z';
-dies-ok { $class."$method"(999, 1) }, '999 is not a valid Z';
+dies-ok { $class."$method"(119, "en") }, '119 is not a valid Z';
+dies-ok { $class."$method"(999, "en") }, '999 is not a valid Z';
 
-dies-ok { $class."$method"(37.3, 1) }, '37.3 is a not valid Z';
+dies-ok { $class."$method"(37.3, "en") }, '37.3 is a not valid Z';
 
 
 # invalid because they are not the right type of value
-dies-ok { $class."$method"('100foo', 1) }, 'A convertible Str is a not valid Z';
-dies-ok { $class."$method"('Some Str', 1) }, 'A Str is not a valid Z';
+dies-ok { $class."$method"('100foo', "en") }, 'A convertible Str is a not valid Z';
+dies-ok { $class."$method"('Some Str', "en") }, 'A Str is not a valid Z';
 
 done-testing;

--- a/t/020.get_name_by_symbol.t
+++ b/t/020.get_name_by_symbol.t
@@ -20,11 +20,11 @@ is
 	$class.get_Z_by_symbol("Br"), 35, "Br is 35";
 
 is
-	$class."$method"("Br", 1), 'Bromine',
+	$class."$method"("Br", "en"), 'Bromine',
 	'Br is Bromine';
 
 is
-	$class."$method"("Br", 2), 'Brom',
+	$class."$method"("Br", "de"), 'Brom',
 	'Br ist Brom';
 	
 
@@ -32,11 +32,11 @@ is
 	$class.get_Z_by_symbol("Ne"), 10, "Ne is 10";
 
 is
-	$class.$callable("Ne", 1), 'Neon',
+	$class.$callable("Ne", "en"), 'Neon',
 	'Ne is Neon';
 
 is
-	$class.$callable("Ne", 2), 'Neon',
+	$class.$callable("Ne", "de"), 'Neon',
 	'Ne ist Neon';
 
 done-testing;


### PR DESCRIPTION
I added a method for convert language strings to the language index needed for the element’s names.
The default language is english.